### PR TITLE
V1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,5 +128,6 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$androidXTestVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'com.kaspersky.android-components:kaspresso:1.4.1'
     androidTestUtil 'androidx.test:orchestrator:1.4.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField 'String', 'SERVER_URL', '"https://10.0.2.2:8443"'
+            buildConfigField 'String', 'SERVER_URL', '"https://gentle-pandas-talk-58-84-143-202.loca.lt"'
             // buildConfigField 'String', 'SERVER_URL', '"http://192.168.20.12:3000"'
         }
 

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/AdbHelpers.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/AdbHelpers.kt
@@ -1,0 +1,35 @@
+package au.edu.unsw.business.studysync
+
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import java.util.*
+
+// A wrapper around Kaspresso's ADB server.
+// The adb server for desktop must be running. You can find it at:
+// https://github.com/KasperskyLab/Kaspresso/tree/master/artifacts
+// A copy can also be found in the app/libs folder in this project.
+object AdbHelpers : TestCase() {
+
+    fun setAdbAutoTime(enabled: Boolean) {
+        if (enabled) {
+            adbServer.performShell("settings put global auto_time 1")
+        } else {
+            adbServer.performShell("settings put global auto_time 0")
+        }
+    }
+
+    private fun setTime(time: String) {
+        // String format is "MMDDhhmmYYYY[.ss]"
+        adbServer.performShell("su 0 toybox date $time; su 0 am broadcast -a android.intent.action.TIME_SET")
+    }
+
+    fun setOneMinuteBeforeMidnightToday() {
+        setAdbAutoTime(false)
+        // Get the current month and day from standard library as padded string
+        val calendar = Calendar.getInstance()
+        val month = (calendar.get(Calendar.MONTH) + 1).toString().padStart(2, '0')
+        val day = calendar.get(Calendar.DAY_OF_MONTH).toString().padStart(2, '0')
+
+        val time = "${month}${day}2359"
+        setTime(time)
+    }
+}

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/AffineExperimentTest.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/AffineExperimentTest.kt
@@ -147,6 +147,10 @@ class AffineExperimentTest {
         // Check that the number of successful treatments is not displayed
         onView(withId(R.id.successes_message))
             .check(matches(not(isDisplayed())))
+
+        // Check that the incentive label shows the correct amount of of $3.50
+        onView(withId(R.id.incentiveView))
+            .check(matches(withText("$3.50")))
     }
 
     private fun testTimeIncrementsCorrectly() {

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/FlexStudyDatesNewTest.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/FlexStudyDatesNewTest.kt
@@ -1,0 +1,105 @@
+package au.edu.unsw.business.studysync
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.CoreMatchers
+import org.junit.*
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FlexStudyDatesNewTest {
+    private lateinit var scenario: ActivityScenario<MainActivity>
+    @Before
+    fun setUp() {
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        UsageHelpers.disableUsagePermission()
+    }
+
+    @After
+    fun tearDown() {
+        scenario.close()
+        UsageHelpers.disableUsagePermission()
+    }
+
+    private fun delay() {
+        // Helper function to delay test execution
+        // for manually inspecting the UI
+        Thread.sleep(1000)
+    }
+    @Test
+    fun testCorrectDateAppearsWhenUsingFlexDatesId() {
+        loginScreenTest()
+        requestPermissionTest()
+        baselineTextTest()
+    }
+
+    private fun loginScreenTest() {
+        // Type in subjectId for control group subject
+        onView(withId(R.id.subjectIdField))
+            .perform(typeText("futureid"))
+            .perform(closeSoftKeyboard())
+
+        // Press submit button
+        onView(withId(R.id.identifyButton))
+            .perform(click())
+
+        // Wait for request permission screen to appear
+        onView(isRoot()).perform(waitForView(R.id.requestPermissionButton, 5000))
+
+        // Check that the screen navigated to the request permission screen
+        onView(withText(R.string.request_permission_title))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton))
+            .check(matches(isDisplayed()))
+    }
+
+    private fun requestPermissionTest() {
+        // Check that the continue button is disabled
+        onView(withId(R.id.continueButton))
+            .check(matches(CoreMatchers.not(isEnabled())))
+
+        // Check that the request permission button is enabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isEnabled()))
+
+        // Press request permission button
+        delay()
+        onView(withId(R.id.requestPermissionButton))
+            .perform(click())
+
+        // Grant permission
+        delay()
+        UsageHelpers.enableUsagePermission()
+        UsageHelpers.goBack()
+
+        // Check that the continue button is enabled
+        onView(withId(R.id.continueButton))
+            .check(matches(isEnabled()))
+
+        // Check that the request permission button is disabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(CoreMatchers.not(isEnabled())))
+
+        // Press continue button
+        delay()
+        onView(withId(R.id.continueButton))
+            .perform(click())
+    }
+
+    private fun baselineTextTest() {
+        // Check that the debrief screen is displayed with the baseline string
+        delay()
+        onView(withText(R.string.baseline_title)).check(matches(isDisplayed()))
+
+        // Check that the date in the text is different from the hardcoded date but matches date from server
+        val baselineText = getText(onView(withId(R.id.textView)))
+        assertTrue(Regex("2024-01-03").containsMatchIn(baselineText))
+    }
+}

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/FlexStudyDatesOldTest.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/FlexStudyDatesOldTest.kt
@@ -1,0 +1,32 @@
+package au.edu.unsw.business.studysync
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.*
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FlexStudyDatesOldTest {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun testOverScreenAppearsWhenUsingOldId() {
+        // Type in subjectId for id that has already done the experiment
+        onView(withId(R.id.subjectIdField))
+            .perform(typeText("aaaaaa000000"))
+            .perform(closeSoftKeyboard())
+
+        // Press submit button
+        onView(withId(R.id.identifyButton))
+            .perform(click())
+
+        // Wait for the next screen to load and check that it's the experiment over screen
+        Thread.sleep(5000)
+        onView(withText(R.string.over_title)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/TallySuccessesAffineTest.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/TallySuccessesAffineTest.kt
@@ -1,0 +1,172 @@
+package au.edu.unsw.business.studysync
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import au.edu.unsw.business.studysync.constants.Constants
+import au.edu.unsw.business.studysync.support.TimeUtils
+import org.hamcrest.CoreMatchers.not
+import org.junit.*
+import org.junit.Assert.assertNotEquals
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TallySuccessesAffineTest {
+    private lateinit var scenario: ActivityScenario<MainActivity>
+
+    @Before
+    fun setUp() {
+        AdbHelpers.setOneMinuteBeforeMidnightToday()
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        UsageHelpers.disableUsagePermission()
+    }
+
+    @After
+    fun tearDown() {
+        scenario.close()
+        UsageHelpers.disableUsagePermission()
+        AdbHelpers.setAdbAutoTime(true)
+    }
+
+    private fun delay() {
+        // Helper function to delay test execution
+        // for manually inspecting the UI
+        Thread.sleep(1000)
+    }
+
+    @Test
+    fun testTallyForAffineGroup() {
+        loginScreenTest()
+        requestPermissionTest()
+        checkTreatmentDebriefInstructions()
+        checkTreatementScreenDetails()
+        testTimeAndTallyIncrementsCorrectly()
+    }
+
+    private fun loginScreenTest() {
+        // Type in subjectId for control group subject
+        onView(withId(R.id.subjectIdField))
+            .perform(typeText("incentive"))
+            .perform(closeSoftKeyboard())
+
+        // Press submit button
+        onView(withId(R.id.identifyButton))
+            .perform(click())
+
+        // Wait for request permission screen to appear
+        onView(isRoot()).perform(waitForView(R.id.requestPermissionButton, 5000))
+
+        // Check that the screen navigated to the request permission screen
+        onView(withText(R.string.request_permission_title))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton))
+            .check(matches(isDisplayed()))
+    }
+
+    private fun requestPermissionTest() {
+        // Check that the continue button is disabled
+        onView(withId(R.id.continueButton))
+            .check(matches(not(isEnabled())))
+
+        // Check that the request permission button is enabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isEnabled()))
+
+        // Press request permission button
+        delay()
+        onView(withId(R.id.requestPermissionButton))
+            .perform(click())
+
+        // Grant permission
+        delay()
+        UsageHelpers.enableUsagePermission()
+        UsageHelpers.goBack()
+
+        // Check that the continue button is enabled
+        onView(withId(R.id.continueButton))
+            .check(matches(isEnabled()))
+
+        // Check that the request permission button is disabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(not(isEnabled())))
+
+        // Press continue button
+        delay()
+        onView(withId(R.id.continueButton))
+            .perform(click())
+    }
+
+    private fun checkTreatmentDebriefInstructions() {
+        // Check that the screen is on the debrief instructions screen
+        onView(withText(R.string.debrief_title))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton)).check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton)).check(matches(isEnabled()))
+
+        // Press continue button
+        delay()
+        onView(withId(R.id.continueButton))
+            .perform(click())
+        delay()
+    }
+
+    private fun checkTreatementScreenDetails() {
+        // Check that we are on the treatment screen
+        onView(withId(R.id.linearLayout))
+            .check(matches(isDisplayed()))
+
+        // Check that the correct treatment hint is displayed for the intercept group
+        onView(withId(R.id.treatmentHintLabel))
+            .check(matches(withText(R.string.treatment_hint)))
+
+        // Check that the progress bar is shown
+        onView(withId(R.id.progress))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.todayUsageView))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.maxUsageView))
+            .check(matches(isDisplayed()))
+
+        // Check that the incentive label appears
+        onView(withId(R.id.incentiveLabel))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.incentiveView))
+            .check(matches(isDisplayed()))
+
+        // Check that the amount earned appears
+        onView(withId(R.id.totalEarnedLabel))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.totalEarnedView))
+            .check(matches(isDisplayed()))
+
+        // Check that the number of successful treatments is not displayed
+        onView(withId(R.id.successes_message))
+            .check(matches(not(isDisplayed())))
+    }
+
+    private fun testTimeAndTallyIncrementsCorrectly() {
+        // Record the value of the progress bar
+        val initialText = getText(onView(withId(R.id.todayUsageView)))
+
+        // Record the value of the incentive label
+        val initialIncentiveText = getText(onView(withId(R.id.totalEarnedView)))
+
+        // Do nothing for 1 minute and 1 second
+        Thread.sleep(61000)
+
+        // Retrieve text and check that it isn't the same as the initial value
+        scenario.recreate()
+        val finalText = getText(onView(withId(R.id.todayUsageView)))
+        assertNotEquals(initialText, finalText)
+
+        // Check that the incentive label has increased
+        val finalIncentiveText = getText(onView(withId(R.id.totalEarnedView)))
+        assertNotEquals(initialIncentiveText, finalIncentiveText)
+        delay()
+    }
+}

--- a/app/src/androidTest/java/au/edu/unsw/business/studysync/TallySuccessesInterceptTest.kt
+++ b/app/src/androidTest/java/au/edu/unsw/business/studysync/TallySuccessesInterceptTest.kt
@@ -1,0 +1,173 @@
+package au.edu.unsw.business.studysync
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import au.edu.unsw.business.studysync.constants.Constants
+import au.edu.unsw.business.studysync.support.TimeUtils
+import org.hamcrest.CoreMatchers.not
+import org.junit.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TallySuccessesInterceptTest {
+    private lateinit var scenario: ActivityScenario<MainActivity>
+
+    @Before
+    fun setUp() {
+        AdbHelpers.setOneMinuteBeforeMidnightToday()
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        UsageHelpers.disableUsagePermission()
+    }
+
+    @After
+    fun tearDown() {
+        scenario.close()
+        UsageHelpers.disableUsagePermission()
+        AdbHelpers.setAdbAutoTime(true)
+    }
+
+    private fun delay() {
+        // Helper function to delay test execution
+        // for manually inspecting the UI
+        Thread.sleep(1000)
+    }
+
+    @Test
+    fun testTallyForInterceptGroup() {
+        loginScreenTest()
+        requestPermissionTest()
+        checkTreatmentDebriefInstructions()
+        checkTreatementScreenDetails()
+        testTimeAndTallyIncrementsCorrectly()
+    }
+
+    private fun loginScreenTest() {
+        // Type in subjectId for control group subject
+        onView(withId(R.id.subjectIdField))
+            .perform(typeText("info"))
+            .perform(closeSoftKeyboard())
+
+        // Press submit button
+        onView(withId(R.id.identifyButton))
+            .perform(click())
+
+        // Wait for request permission screen to appear
+        onView(isRoot()).perform(waitForView(R.id.requestPermissionButton, 5000))
+
+        // Check that the screen navigated to the request permission screen
+        onView(withText(R.string.request_permission_title))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton))
+            .check(matches(isDisplayed()))
+    }
+
+    private fun requestPermissionTest() {
+        // Check that the continue button is disabled
+        onView(withId(R.id.continueButton))
+            .check(matches(not(isEnabled())))
+
+        // Check that the request permission button is enabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(isEnabled()))
+
+        // Press request permission button
+        delay()
+        onView(withId(R.id.requestPermissionButton))
+            .perform(click())
+
+        // Grant permission
+        delay()
+        UsageHelpers.enableUsagePermission()
+        UsageHelpers.goBack()
+
+        // Check that the continue button is enabled
+        onView(withId(R.id.continueButton))
+            .check(matches(isEnabled()))
+
+        // Check that the request permission button is disabled
+        onView(withId(R.id.requestPermissionButton))
+            .check(matches(not(isEnabled())))
+
+        // Press continue button
+        delay()
+        onView(withId(R.id.continueButton))
+            .perform(click())
+    }
+
+    private fun checkTreatmentDebriefInstructions() {
+        // Check that the screen is on the debrief instructions screen
+        onView(withText(R.string.debrief_title))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton)).check(matches(isDisplayed()))
+        onView(withId(R.id.continueButton)).check(matches(isEnabled()))
+
+        // Press continue button
+        delay()
+        onView(withId(R.id.continueButton))
+            .perform(click())
+        delay()
+    }
+
+    private fun checkTreatementScreenDetails() {
+        // Check that we are on the treatment screen
+        onView(withId(R.id.linearLayout))
+            .check(matches(isDisplayed()))
+
+        // Check that the correct treatment hint is displayed for the intercept group
+        onView(withId(R.id.treatmentHintLabel))
+            .check(matches(withText(R.string.treatment_hint_intercept)))
+
+        // Check that the progress bar is shown
+        onView(withId(R.id.progress))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.todayUsageView))
+            .check(matches(isDisplayed()))
+        onView(withId(R.id.maxUsageView))
+            .check(matches(isDisplayed()))
+
+        // Check that the incentive label does not appear
+        onView(withId(R.id.incentiveLabel))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.incentiveView))
+            .check(matches(not(isDisplayed())))
+
+        // Check that the amount earned does not appear
+        onView(withId(R.id.totalEarnedLabel))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.totalEarnedView))
+            .check(matches(not(isDisplayed())))
+
+        // Check that the number of successful treatments is displayed
+        onView(withId(R.id.successes_message))
+            .check(matches(isDisplayed()))
+    }
+
+    private fun testTimeAndTallyIncrementsCorrectly() {
+        // Record the value of the progress bar
+        val initialText = getText(onView(withId(R.id.todayUsageView)))
+
+        // Record the value of the target counter
+        val initialTarget = getText(onView(withId(R.id.successes_message)))
+
+        // Do nothing for 1 minute and 1 second
+        Thread.sleep(61000)
+
+        // Retrieve text and check that it isn't the same as the initial value
+        scenario.recreate()
+        val finalText = getText(onView(withId(R.id.todayUsageView)))
+        assertNotEquals(initialText, finalText)
+
+        // Check that the target incremented by 1
+        val finalTarget = getText(onView(withId(R.id.successes_message)))
+        assertNotEquals(initialTarget, finalTarget)
+        delay()
+    }
+}

--- a/app/src/main/java/au/edu/unsw/business/studysync/SubjectSettings.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/SubjectSettings.kt
@@ -7,6 +7,11 @@ import androidx.lifecycle.MutableLiveData
 import au.edu.unsw.business.studysync.constants.Constants.GROUP_UNASSIGNED
 import au.edu.unsw.business.studysync.constants.Environment
 import au.edu.unsw.business.studysync.constants.Environment.BASELINE_DATE_STRING
+import au.edu.unsw.business.studysync.constants.Environment.ENDLINE_DATE_STRING
+import au.edu.unsw.business.studysync.constants.Environment.OVER_DATE_STRING
+import au.edu.unsw.business.studysync.constants.Environment.TREATMENT_DATE_STRING
+import au.edu.unsw.business.studysync.support.StudyDates
+import au.edu.unsw.business.studysync.support.TimeUtils
 import org.acra.ACRA
 import java.time.Duration
 import java.time.LocalDate
@@ -50,6 +55,13 @@ class SubjectSettings(private val preferences: SharedPreferences) {
         if (static.subjectId != null) {
             ACRA.errorReporter.putCustomData("SUBJECT_ID", static.subjectId)
         }
+
+        TimeUtils.studyDates = StudyDates(
+            static.baselineDate,
+            static.treatmentDate,
+            static.endlineDate,
+            static.overDate
+        )
     }
 
     fun identify(subjectId: String, authToken: String) {
@@ -110,6 +122,22 @@ class SubjectSettings(private val preferences: SharedPreferences) {
 
         _treatmentDebriefed.value = true
     }
+
+    fun updateDates(baselineDate: String, treatmentDate: String, endlineDate: String, overDate: String) {
+        preferences.edit {
+            putString("baseline-date", baselineDate)
+            putString("treatment-date", treatmentDate)
+            putString("endline-date", endlineDate)
+            putString("over-date", overDate)
+        }
+
+        TimeUtils.studyDates = StudyDates(
+            baselineDate = LocalDate.parse(baselineDate),
+            treatmentDate = LocalDate.parse(treatmentDate),
+            endlineDate = LocalDate.parse(endlineDate),
+            overDate = LocalDate.parse(overDate)
+        )
+    }
 }
 
 data class StaticSubjectSettings(val preferences: SharedPreferences) {
@@ -121,4 +149,8 @@ data class StaticSubjectSettings(val preferences: SharedPreferences) {
     val treatmentIntensity: Int = preferences.getInt("treatment-intensity", 0)
     val treatmentDebriefed: Boolean = preferences.getBoolean("treatment-debriefed", false)
     val treatmentLimit: Duration = Duration.ofSeconds(preferences.getInt("treatment-limit", 0).toLong())
+    val baselineDate: LocalDate = LocalDate.parse(preferences.getString("baseline-date", BASELINE_DATE_STRING)!!)
+    val treatmentDate: LocalDate = LocalDate.parse(preferences.getString("treatment-date", TREATMENT_DATE_STRING)!!)
+    val endlineDate: LocalDate = LocalDate.parse(preferences.getString("endline-date", ENDLINE_DATE_STRING)!!)
+    val overDate: LocalDate = LocalDate.parse(preferences.getString("over-date", OVER_DATE_STRING)!!)
 }

--- a/app/src/main/java/au/edu/unsw/business/studysync/constants/Constants.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/constants/Constants.kt
@@ -1,5 +1,6 @@
 package au.edu.unsw.business.studysync.constants
 
+import au.edu.unsw.business.studysync.support.TimeUtils
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -20,6 +21,7 @@ object Constants {
     const val DAILY_SCHEDULER_WORK = "DAILY_SCHEDULER_WORK"
     const val DAILY_SCHEDULER_BOUNCE_WORK = "DAILY_SCHEDULER_BOUNCE_WORK"
     const val FETCH_TEST_PARAMS_WORK = "FETCH_TEST_PARAMS_WORK"
+    const val DAILY_CHECK_STUDY_DATES = "DAILY_CHECK_STUDY_DATES"
     const val PREFERENCES_NAME = "studysync-config"
 
     const val STUDY_PHASE_CHANNEL = "STUDY_PHASE_CHANNEL"
@@ -54,6 +56,6 @@ object Environment {
     }
 
     val BASELINE_LENGTH: Int by lazy {
-        ChronoUnit.DAYS.between(BASELINE_DATE, TREATMENT_DATE).toInt()
+        ChronoUnit.DAYS.between(TimeUtils.studyDates.baselineDate, TimeUtils.studyDates.treatmentDate).toInt()
     }
 }

--- a/app/src/main/java/au/edu/unsw/business/studysync/fragments/LoginFragment.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/fragments/LoginFragment.kt
@@ -51,6 +51,21 @@ class LoginFragment : Fragment() {
 
                     val idData = idResponse.data!!
 
+                    // Retrieve the study dates from the server
+                    val studyDatesResponse = SyncApi.service.getDates(idData.authToken, subjectId)
+
+                    if (studyDatesResponse.message != null) throw Exception(studyDatesResponse.message)
+
+                    val studyDates = studyDatesResponse.data!!
+
+                    // If no dates are null then update the study dates in the time utils
+                    if (studyDates.baselineDate != null &&
+                        studyDates.treatmentDate != null &&
+                        studyDates.endlineDate != null &&
+                        studyDates.overDate != null) {
+                        vm.updateDates(studyDates.baselineDate, studyDates.treatmentDate, studyDates.endlineDate, studyDates.overDate)
+                    }
+
                     if (TimeUtils.getTodayPeriod() == PERIOD_BASELINE) {
                         vm.identify(subjectId, idData.authToken)
                     } else {

--- a/app/src/main/java/au/edu/unsw/business/studysync/network/ApiResponse.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/network/ApiResponse.kt
@@ -24,3 +24,14 @@ data class GetTestParamsResponse(
     @Json(name = "treatment_limit")
     val treatmentLimit: Int?
 )
+
+data class GetDatesResponse(
+    @Json(name = "baseline_date")
+    val baselineDate: String?,
+    @Json(name = "treatment_date")
+    val treatmentDate: String?,
+    @Json(name = "endline_date")
+    val endlineDate: String?,
+    @Json(name = "over_date")
+    val overDate: String?
+)

--- a/app/src/main/java/au/edu/unsw/business/studysync/network/SyncApi.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/network/SyncApi.kt
@@ -26,6 +26,9 @@ interface SyncApiService {
 
     @POST("api/submit-report")
     suspend fun submitReport(@Header("Authorization") authToken: String, @Body reportPayload: ReportPayload): BasicApiResponse
+
+    @GET("api/get-dates")
+    suspend fun getDates(@Header("Authorization") authToken: String?, @Query("subject_id") subjectId: String?): ApiResponse<GetDatesResponse>
 }
 
 object SyncApi {

--- a/app/src/main/java/au/edu/unsw/business/studysync/support/MessageUtils.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/support/MessageUtils.kt
@@ -60,7 +60,7 @@ object MessageUtils {
     }
 
     fun endlineBody(@ColorInt highlightColor: Int): Spannable {
-        return SpannableStringBuilder("Please check your email for the endline survey. Upon completion of the endline survey, your total earnings from the study (if applicable) along with \$25 for completing the surveys will be paid to your nominated PayID account within a week. If you have any questions, please contact the research team at unswsmartphonestudy@gmail.com.\n\nPlease keep the app installed until ")
+        return SpannableStringBuilder("Please check your email for the invitation to the Endline Survey.  Upon completion of the Endline Survey, your total earnings from this portion of the study (if any) along with \$25 for completing the surveys will be paid to your nominated PayID account within a week.  If you have any questions, please contact the research team at unswsmartphoneproject@gmail.com.\n\nPlease keep the app installed until ")
             .bold {
                 color(highlightColor) {
                     append(TimeUtils.studyDates.overDate.toString())

--- a/app/src/main/java/au/edu/unsw/business/studysync/support/MessageUtils.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/support/MessageUtils.kt
@@ -6,14 +6,13 @@ import androidx.annotation.ColorInt
 import androidx.core.text.bold
 import androidx.core.text.color
 import androidx.core.text.toSpannable
-import au.edu.unsw.business.studysync.constants.Environment
 
 object MessageUtils {
     fun baselineBody(@ColorInt highlightColor: Int): Spannable {
         return SpannableStringBuilder("You do not need to do anything else at the moment. Please keep this app installed for the duration of the study. You will be asked to complete an endline survey on ")
             .bold {
                 color(highlightColor) {
-                    append(Environment.ENDLINE_DATE.toString())
+                    append(TimeUtils.studyDates.endlineDate.toString())
                 }
             }
             .append(".\n\nThank you for your participation!")
@@ -30,7 +29,7 @@ object MessageUtils {
             .append(" each day. The app will keep a running tally of all the days for which you have met this target over the four week period starting on ")
             .bold {
                 color(highlightColor) {
-                    append(Environment.TREATMENT_DATE.toString())
+                    append(TimeUtils.studyDates.treatmentDate.toString())
                 }
             }
             .append(". Note that you will not receive monetary compensation for hitting your target.\n\nPlease keep this app installed for the duration of the study and thank you for your participation!")
@@ -53,7 +52,7 @@ object MessageUtils {
             .append(" each day. The app will keep a running tally of the reward that you have earned over the four week period starting on ")
             .bold {
                 color(highlightColor) {
-                    append(Environment.TREATMENT_DATE.toString())
+                    append(TimeUtils.studyDates.treatmentDate.toString())
                 }
             }
             .append(".\n\nPlease keep this app installed for the duration of the study and thank you for your participation!")
@@ -64,7 +63,7 @@ object MessageUtils {
         return SpannableStringBuilder("Please check your email for the endline survey. Upon completion of the endline survey, your total earnings from the study (if applicable) along with \$25 for completing the surveys will be paid to your nominated PayID account within a week. If you have any questions, please contact the research team at unswsmartphonestudy@gmail.com.\n\nPlease keep the app installed until ")
             .bold {
                 color(highlightColor) {
-                    append(Environment.OVER_DATE.toString())
+                    append(TimeUtils.studyDates.overDate.toString())
                 }
             }
             .append(", at which point you will be given instructions regarding deletion of the app. If you do so, you will also be entered into a lottery to win $100.\n\nThank you for your participation!")

--- a/app/src/main/java/au/edu/unsw/business/studysync/support/StudyDates.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/support/StudyDates.kt
@@ -1,0 +1,10 @@
+package au.edu.unsw.business.studysync.support
+
+import java.time.LocalDate
+
+data class StudyDates(
+    val baselineDate: LocalDate,
+    val treatmentDate: LocalDate,
+    val endlineDate: LocalDate,
+    val overDate: LocalDate
+)

--- a/app/src/main/java/au/edu/unsw/business/studysync/support/TimeUtils.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/support/TimeUtils.kt
@@ -4,6 +4,7 @@ import au.edu.unsw.business.studysync.constants.Constants.PERIOD_BASELINE
 import au.edu.unsw.business.studysync.constants.Constants.PERIOD_ENDLINE
 import au.edu.unsw.business.studysync.constants.Constants.PERIOD_EXPERIMENT
 import au.edu.unsw.business.studysync.constants.Constants.PERIOD_OVER
+import au.edu.unsw.business.studysync.constants.Environment.BASELINE_DATE
 import au.edu.unsw.business.studysync.constants.Environment.BASELINE_LENGTH
 import au.edu.unsw.business.studysync.constants.Environment.ENDLINE_DATE
 import au.edu.unsw.business.studysync.constants.Environment.OVER_DATE
@@ -20,12 +21,13 @@ object TimeUtils {
     // val TIME_DELAY = Duration.ofHours(23).plusMinutes(54)
     val TIME_DELAY = Duration.ZERO
     var periodToday: String? = null // Used for testing purposes to mock date
+    var studyDates = StudyDates(BASELINE_DATE, TREATMENT_DATE, ENDLINE_DATE, OVER_DATE)
 
     fun getPeriod(date: LocalDate): String {
         return when {
-            date.isBefore(TREATMENT_DATE) -> PERIOD_BASELINE
-            date.isBefore(ENDLINE_DATE) -> PERIOD_EXPERIMENT
-            date.isBefore(OVER_DATE) -> PERIOD_ENDLINE
+            date.isBefore(studyDates.treatmentDate) -> PERIOD_BASELINE
+            date.isBefore(studyDates.endlineDate) -> PERIOD_EXPERIMENT
+            date.isBefore(studyDates.overDate) -> PERIOD_ENDLINE
             else -> PERIOD_OVER
         }
     }
@@ -97,8 +99,8 @@ object TimeUtils {
 
     fun getStudyPeriodAndDay(d: LocalDate): Pair<String, Int> {
         // Days start at 0
-        val treatmentTime = ChronoUnit.DAYS.between(TREATMENT_DATE, d).toInt()
-        val endlineTime = ChronoUnit.DAYS.between(ENDLINE_DATE, d).toInt()
+        val treatmentTime = ChronoUnit.DAYS.between(studyDates.treatmentDate, d).toInt()
+        val endlineTime = ChronoUnit.DAYS.between(studyDates.endlineDate, d).toInt()
 
         return when {
             treatmentTime < 0 -> Pair(PERIOD_BASELINE, treatmentTime + BASELINE_LENGTH)

--- a/app/src/main/java/au/edu/unsw/business/studysync/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/viewmodels/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
 import au.edu.unsw.business.studysync.StudySyncApplication
+import au.edu.unsw.business.studysync.support.StudyDates
 import au.edu.unsw.business.studysync.support.UsageUtils
 import com.jakewharton.rxrelay3.PublishRelay
 import io.reactivex.rxjava3.core.Observable
@@ -60,6 +61,11 @@ class MainViewModel(private val application: StudySyncApplication): AndroidViewM
 
     fun completeDebrief() {
         subjectSettings.completeDebrief()
+        _navigateEvents.accept(Unit)
+    }
+
+    fun updateDates(baselineDate: String, treatmentDate: String, endlineDate: String, overDate: String) {
+        subjectSettings.updateDates(baselineDate, treatmentDate, endlineDate, overDate)
         _navigateEvents.accept(Unit)
     }
 }

--- a/app/src/main/java/au/edu/unsw/business/studysync/workers/FetchTestParametersWorker.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/workers/FetchTestParametersWorker.kt
@@ -11,7 +11,7 @@ class FetchTestParametersWorker(private val context: Context, params: WorkerPara
     override suspend fun doWork(): Result {
         try {
             val preferences = context.getSharedPreferences("studysync-config", Context.MODE_PRIVATE)
-            val subjectSettings = SubjectSettings(preferences)
+            val subjectSettings = SubjectSettings(preferences) // Does this throw "Cannot invoke setValue in a background thread"?
 
             val result = RobustFetchTestParameters.fetch(subjectSettings.authToken.value!!, subjectSettings.subjectId.value!!)
 

--- a/app/src/main/java/au/edu/unsw/business/studysync/workers/UpdateStudyDatesWorker.kt
+++ b/app/src/main/java/au/edu/unsw/business/studysync/workers/UpdateStudyDatesWorker.kt
@@ -1,0 +1,49 @@
+package au.edu.unsw.business.studysync.workers
+
+import android.content.Context
+import android.util.Log
+import androidx.core.content.edit
+import androidx.work.*
+import au.edu.unsw.business.studysync.SubjectSettings
+import au.edu.unsw.business.studysync.network.SyncApi
+import org.acra.ACRA
+import java.time.Duration
+
+class UpdateStudyDatesWorker(private val context: Context, params: WorkerParameters): CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result {
+        try {
+            val preferences = context.getSharedPreferences("studysync-config", Context.MODE_PRIVATE)
+
+            val result = SyncApi.service.getDates(preferences.getString("auth-token", null), preferences.getString("subject-id", null))
+
+            if (result.message != null) throw Exception(result.message)
+
+            val studyDates = result.data!!
+
+            if (studyDates.baselineDate != null &&
+                studyDates.treatmentDate != null &&
+                studyDates.endlineDate != null &&
+                studyDates.overDate != null) {
+                preferences.edit {
+                    putString("baseline-date", studyDates.baselineDate)
+                    putString("treatment-date", studyDates.treatmentDate)
+                    putString("endline-date", studyDates.endlineDate)
+                    putString("over-date", studyDates.overDate)
+                }
+            }
+            return Result.success()
+        } catch (ex: Exception) {
+            ACRA.errorReporter.handleSilentException(ex)
+            Log.d("UpdateStudyDatesWorker", ex.message!!)
+            return Result.retry()
+        }
+    }
+
+    companion object {
+        fun createRequest(): OneTimeWorkRequest {
+            return OneTimeWorkRequestBuilder<UpdateStudyDatesWorker>()
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, Duration.ofHours(1))
+                .build()
+        }
+    }
+}


### PR DESCRIPTION
Converted dates from a constant into their own class since it won't be a constant anymore. Made `TimeUtils.studyDates` the main data source for dates. It will still work with the hardcoded dates and will use them if it can't get dates from the server. 

Add tests for flex dates. These will require a dev server running with the latest changes. I have also done extensive testing of the study date worker by modifying the time on my phone and checking that the expected outcome occurs. 

Currently, it will check the dates every day and on entering your id. If necessary, I can also make it check the dates when the app is opened however this seems unnecessary.